### PR TITLE
Add ReachOut.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ Before you start, please read our [contributor guidelines](CONTRIBUTING.md)!
 
 - [Alpine Linux](https://wiki.alpinelinux.org/wiki/Alpine_Linux:Contribute)
 - [Arch](https://wiki.archlinux.org/index.php/getting_involved)
+- [ArchLabs](https://www.patreon.com/archlabslinux)
+- [ArcoLinux](https://arcolinux.info/donation/)
+- [CentOS](https://wiki.centos.org/Contribute)
 - [Debian](https://www.debian.org/intro/help)
 - [elementary OS](https://elementary.io/get-involved#support)
 - Fedora Project
@@ -186,6 +189,7 @@ Before you start, please read our [contributor guidelines](CONTRIBUTING.md)!
   - [Join Fedora](https://fedoraproject.org/wiki/Join)
   - [Contributing to Fedora](https://ask.fedoraproject.org/c/community/contributing-to-fedora) on [Ask Fedora](https://ask.fedoraproject.org/)
 - [Gentoo](https://wiki.gentoo.org/wiki/Contributing_to_Gentoo)
+- [Kali](https://docs.kali.org/contribute)
 - [Linux Mint](https://linuxmint.com/getinvolved.php)
 - [Lubuntu](https://lubuntu.me/links/)
 - [Mageia](https://www.mageia.org/contribute/)
@@ -193,9 +197,12 @@ Before you start, please read our [contributor guidelines](CONTRIBUTING.md)!
 - [MX Linux](https://mxlinux.org/donate/)
 - [OpenMediaVault](https://openmediavault.readthedocs.io/en/latest/development/contribute.html)
 - [openSUSE](https://en.opensuse.org/Portal:How_to_participate)
+- [PCLinuxOS](https://www.pclinuxos.com/donations/)
 - [Pop!_OS](https://system76.com/pop/community)
 - [Proxmox Virtualization](https://www.proxmox.com/en/proxmox-ve/get-involved)
+- [Slackware](https://docs.slackware.com/slackware:community)
 - [Solus](https://getsol.us/articles/contributing/getting-involved/en/)
+- [Tails](https://tails.boum.org/donate)
 - [Ubuntu](https://wiki.ubuntu.com/ContributeToUbuntu)
 - [Ubuntu Budgie](https://discourse.ubuntubudgie.org/c/Get-Involved?status=open)
 - [Ubuntu Mate](https://ubuntu-mate.org/community/)
@@ -208,6 +215,7 @@ Before you start, please read our [contributor guidelines](CONTRIBUTING.md)!
 - [GhostBSD](https://ghostbsd.org/contribute)
 - [OpenBSD](https://www.openbsd.org/faq/faq1.html#Support)
 - [OPNsense](https://docs.opnsense.org/contribute.html)
+- [pfSense](https://www.pfsense.org/get-involved/)
 
 #### Other
 
@@ -222,6 +230,7 @@ Before you start, please read our [contributor guidelines](CONTRIBUTING.md)!
 - [GNOME](https://www.gnome.org/get-involved/)
 - [KDE](https://community.kde.org/Get_Involved)
 - [LXQt](https://github.com/lxqt/lxqt/blob/master/CONTRIBUTING.md)
+- [MATE](https://mate-desktop.org/donate/)
 - [Xfce](https://www.xfce.org/getinvolved)
 
 ### Display Servers

--- a/ReachOut.md
+++ b/ReachOut.md
@@ -1,0 +1,15 @@
+#Reaching Out
+
+The purpose of this document is to give simple, concise talking points on communicating the effectiveness of a good "Get Involved" page.
+
+##Front and Center
+People naturally want to help. Making your get-involved page easy to find shows that a project is invested in its community and is welcome to contributions. Using community standard wording such as 'Get Involved', 'Participation' and 'Contribution' on your Home Page makes it easy for the reader to identify.  
+
+##Offer to help!
+Project developers are often juggling their project with other obligations such as work or family. Offering to help design a get-involved page could be one of the best ways you can help out!
+
+##More than a Donate button
+Emphasize that there are multiple ways volunteers can help with any project, not just contributing financially.  Translation, support and raising awareness are all effective ways to drum up support for a FOSS project. Link them to the [How you can help guide](https://github.com/killyourfm/contribute-foss#identifying-how-you-can-help) written by Jason Evangelho for tips on effectively engaging with a community.  
+
+##Simple, Concise Design
+Direct them to effective get-involved pages, such as the one at [pfSense](https://www.pfsense.org/get-involved/) for ideas on simple, concise layouts. Having an easy to find, easy to navigate get-involved page encourages support from the community.

--- a/ReachOut.md
+++ b/ReachOut.md
@@ -1,15 +1,15 @@
-#Reaching Out
+## Reaching Out
 
 The purpose of this document is to give simple, concise talking points on communicating the effectiveness of a good "Get Involved" page.
 
-##Front and Center
+### Front and Center
 People naturally want to help. Making your get-involved page easy to find shows that a project is invested in its community and is welcome to contributions. Using community standard wording such as 'Get Involved', 'Participation' and 'Contribution' on your Home Page makes it easy for the reader to identify.  
 
-##Offer to help!
+### Offer to help!
 Project developers are often juggling their project with other obligations such as work or family. Offering to help design a get-involved page could be one of the best ways you can help out!
 
-##More than a Donate button
+### More than a Donate button
 Emphasize that there are multiple ways volunteers can help with any project, not just contributing financially.  Translation, support and raising awareness are all effective ways to drum up support for a FOSS project. Link them to the [How you can help guide](https://github.com/killyourfm/contribute-foss#identifying-how-you-can-help) written by Jason Evangelho for tips on effectively engaging with a community.  
 
-##Simple, Concise Design
+### Simple, Concise Design
 Direct them to effective get-involved pages, such as the one at [pfSense](https://www.pfsense.org/get-involved/) for ideas on simple, concise layouts. Having an easy to find, easy to navigate get-involved page encourages support from the community.


### PR DESCRIPTION
When searching some of my familiar projects for get-involved pages, I noticed a lot of them had very minimal pages, or they were difficult to find.  Proposing the creation of a document that would give a user some talking points for reaching out to a FOSS Project Owner and discussing with them establishing a get-involved page for their project.  This document could also include boilerplate emails in the future to reach out to project owners with.